### PR TITLE
performance increase for building docker image

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -19,15 +19,16 @@ LABEL git-commit-id=${git_commit_id} \
       jenkins-build-id=${jenkins_build_id} \
       jenkins-build-number=${jenkins_build_number}
 
-WORKDIR /api-proxy
-COPY src/ ./src/
-
 RUN apt-get update \
  && apt-get -y install --no-install-recommends ca-certificates curl git \
  && curl -sSLO https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf go1.5.1.linux-amd64.tar.gz \
- && rm -f go1.5.1.linux-amd64.tar.gz \
- && export PATH=$PATH:/usr/local/go/bin \
+ && rm -f go1.5.1.linux-amd64.tar.gz
+
+WORKDIR /api-proxy
+COPY src/ ./src/
+
+RUN export PATH=$PATH:/usr/local/go/bin \
  && export GOPATH=/api-proxy \
  && go get "github.com/golang/glog" \
  && go build -o bin/api-proxy src/api-proxy/api-proxy.go \


### PR DESCRIPTION
moves the deps install before copying the source code. this speeds things up dramatically if you are building the docker file alot locally.